### PR TITLE
Put postfix SMTP client into TLS-mode

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -16,6 +16,9 @@ postconf -e myhostname=$mailserver
 postconf -e mydomain=$mailserver
 postconf -F '*/*/chroot = n'
 postconf -e message_size_limit=26214400
+postconf -e smtp_tls_security_level=may
+postconf -e smtp_tls_loglevel=1
+
 
 ## Setup virtual aliases, generate /etc/postfix/virtual from /root/domains
 declare -A domains


### PR DESCRIPTION
Put postfix SMTP client into Opportunistic-TLS-mode. SMTP transaction is encrypted if the STARTTLS ESMTP feature is supported by the server (e.g. forwarding to gmail account)